### PR TITLE
Env vars: allow them to work

### DIFF
--- a/src/env/index.js
+++ b/src/env/index.js
@@ -164,14 +164,12 @@ function _validateThemeId() {
   const themeId = getThemeIdValue();
 
   if (themeId.length === 0) {
-    errors.push(
-      new Error(`${config.get('env.keys.themeId')} must not be empty`)
-    );
+    errors.push(new Error(`${config.get('env.keys.id')} must not be empty`));
   } else if (themeId !== 'live' && !/^\d+$/.test(themeId)) {
     errors.push(
       new Error(
         `${config.get(
-          'env.keys.themeId'
+          'env.keys.id'
         )} can be set to 'live' or a valid theme ID containing only numbers`
       )
     );

--- a/src/env/index.js
+++ b/src/env/index.js
@@ -1,4 +1,5 @@
 const PackerConfig = require('../config');
+const chalk = require('chalk');
 
 const config = new PackerConfig(require('./packer-env.schema'));
 
@@ -21,8 +22,18 @@ const DEFAULT_ENV_VARS = [
 
 function assign(envName = undefined) {
   const name = typeof envName === 'undefined' ? 'development' : envName;
-  const env = require(config.get('packer.env'));
   process.env[config.get('env.keys.name')] = name;
+
+  const packerEnvFile = config.get('packer.env');
+  let env;
+  try {
+    env = require(packerEnvFile);
+  } catch (err) {
+    console.error(
+      chalk.red(`\nFailed to read ${packerEnvFile}, using env variables\n`)
+    );
+    return;
+  }
   DEFAULT_ENV_VARS.forEach((key) => {
     process.env[key] = env[name][_getConfigKey(key)];
   });


### PR DESCRIPTION
Env vars: don't overrwite them if there's no config

Previously, commands like `packer deploy` would *require* there to be a
packer.env.json config file or it'd crash. It seems like env vars were
supposed to be allowed as a way to configure packer. But, if you *did*
provide a config file, all your env vars would be overridden.

Here we print an error message if the packer.env.json file can't be
found, but continue, assuming that the environment contains the needed
vars.


cr_req 1

Local copy of submitted upstream pull: https://github.com/hayes0724/shopify-packer/pull/184